### PR TITLE
修复 IME 组合输入时回车误触发送

### DIFF
--- a/src/components/views/chat-view.tsx
+++ b/src/components/views/chat-view.tsx
@@ -681,13 +681,13 @@ export function ChatView({
                     setSlashMenuOpen(false)
                     return
                   }
-                  if (e.key === 'Enter' && !e.shiftKey) {
+                  if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
                     e.preventDefault()
                     handleSlashSelect(filteredCommands[slashIndex])
                     return
                   }
                 }
-                if (e.key === 'Enter' && !e.shiftKey) {
+                if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
                   e.preventDefault()
                   handleSend()
                 }


### PR DESCRIPTION
## 修复内容

在聊天输入框中，当使用中文（或日文、韩文）输入法输入内容时，按回车键确认当前候选词（IME 组合结束）会误触发消息发送或斜杠命令选择，导致输入内容尚未输入完成就被发出。

## 原因

`onKeyDown` 中的 Enter 键处理没有检查 `e.nativeEvent.isComposing`。IME 组合期间该值为 `true`，但原条件 `e.key === 'Enter' && !e.shiftKey` 未排除此场景，导致组合确认键与发送键冲突。

## 修改

在 `src/components/views/chat-view.tsx` 的两处 Enter 处理条件中增加 `!e.nativeEvent.isComposing` 检查：

1. 斜杠命令菜单的 Enter 选择
2. 消息发送的 Enter 触发

IME 组合期间按回车只做输入法的选词确认，不发送消息；组合结束后按回车正常发送。